### PR TITLE
CMakeLists.txt: fix cmake-4 build (raise minimum version to 3.10)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.10)
 
 set(target blur_image)
 


### PR DESCRIPTION
Without the change the build on cmake-4 fails as:

    CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
      Compatibility with CMake < 3.5 has been removed from CMake.

## Sourcery 摘要

构建:
- 将 `cmake_minimum_required` 从 2.8.11 升级到 3.10

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Bump cmake_minimum_required from 2.8.11 to 3.10

</details>